### PR TITLE
修复第一篇和最后一篇文章的错误

### DIFF
--- a/post.php
+++ b/post.php
@@ -19,8 +19,8 @@
                     <?php $this->content(); ?>
                 </div>
                 <div class="prevornext">
-                    <p><?php $this->theNext(); ?></p>
-                    <p><?php $this->thePrev(); ?></p>
+                    <p><?php $this->theNext('%s', '已经是最新的文章啦'); ?></p>
+                    <p><?php $this->thePrev('%s', '这是第一篇文章喔'); ?></p>
                 </div>
                 <?php _getHistoryToday($this->created) ?>
             </div>


### PR DESCRIPTION
问题详情：打开第一篇文章时，“上一篇文章”显示空白。同理最后一篇文章的“下一篇文章”显示空白
解决方案：给theNext()和thePrev()函数加上默认参数

Signed-off-by: huanglin <huanglin0214@outlook.com>